### PR TITLE
Do not call gun.user() on dev server, only browser

### DIFF
--- a/src/lib/state/gun.svelte.ts
+++ b/src/lib/state/gun.svelte.ts
@@ -66,7 +66,13 @@ export const gun = Gun({
 // Authentication state store
 export const isAuthenticating = writable(true);
 
-export let user = gun.user().recall({ sessionStorage: true });
+export let user: any;
+
+if (typeof window !== 'undefined') {
+	user = gun.user().recall({ sessionStorage: true });
+} else {
+	user = { _:{ sea: null }, is: null };
+}
 
 // SEA.throw = true
 


### PR DESCRIPTION
This was needed for me to `bun run dev` locally.
Minimal change to skip one call in node/bun (which is the dev server). Should not effect production build.