### PR TITLE
Potential fix for code scanning alert no. 19: Use of externally-controlled format string

### DIFF
--- a/src/lib/examples/notifications/service-worker.ts
+++ b/src/lib/examples/notifications/service-worker.ts
@@ -279,7 +279,7 @@ sw.addEventListener('message', async (event) => {
 		try {
 			await handler();
 		} catch (error) {
-			console.error(`[SW] Handler error for ${message.type}:`, error);
+			console.error('[SW] Handler error for %s:', message.type, error);
 		}
 	}
 });


### PR DESCRIPTION
Potential fix for [https://github.com/interplaynetary/free-association/security/code-scanning/19](https://github.com/interplaynetary/free-association/security/code-scanning/19)

To fix the issue, we will ensure that the untrusted `message.type` value is safely included in the log message. Instead of directly embedding it in the template literal, we will use a `%s` format specifier and pass `message.type` as an argument to `console.error`. This approach ensures that the value is treated as a string and prevents any unintended behavior caused by malicious input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
