### PR TITLE
Potential fix for code scanning alert no. 18: Use of externally-controlled format string

### DIFF
--- a/src/lib/examples/notifications/service-worker.ts
+++ b/src/lib/examples/notifications/service-worker.ts
@@ -207,7 +207,7 @@ async function handleDataChange(
 
 		console.log(`[SW] Notification sent for ${subscription.id}`);
 	} catch (error) {
-		console.error(`[SW] Notification error for ${subscription.id}:`, error);
+		console.error(`[SW] Notification error for %s:`, subscription.id, error);
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/interplaynetary/free-association/security/code-scanning/18](https://github.com/interplaynetary/free-association/security/code-scanning/18)

To fix the issue, the untrusted `subscription.id` value should be passed as a separate argument to the format string using the `%s` specifier. This ensures that the value is treated as a string and prevents any unintended format specifiers from being interpreted.

**Steps to fix:**
1. Update the logging statement on line 210 to use a `%s` specifier in the format string.
2. Pass `subscription.id` as a separate argument to `console.error`.

No additional imports, methods, or definitions are required to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
