### PR TITLE
Create deployment archive

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -7,9 +7,8 @@ on:
     paths:
       - 'src/routes/api/**'
       - 'src/lib/server/**'
-      - 'server/**'
       - 'package.json'
-      - 'bun.lockb'
+      - 'bun.lock'
       - '.github/workflows/deploy-server.yml'
   workflow_dispatch:  # Allow manual triggers
 
@@ -49,12 +48,10 @@ jobs:
         run: |
           # Create archive with build output and necessary files
           tar -czf deploy.tar.gz \
+            --exclude='*.log' \
             build-server/ \
-            server/ \
             package.json \
-            bun.lockb \
-            --exclude='server/*/node_modules' \
-            --exclude='*.log'
+            bun.lock
 
       - name: Deploy to DigitalOcean
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
Fix `tar` command in deploy workflow to resolve build failures caused by incorrect file paths and option placement.

The previous `tar` command in the `deploy-server.yml` workflow was failing due to three main issues: referencing a non-existent `server/` directory, using the incorrect lockfile name (`bun.lockb` instead of `bun.lock`), and incorrect placement of `--exclude` options after file arguments. This PR corrects these issues to ensure the deployment archive is created successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ee3b389-716f-4ffe-b51d-f2ba836753a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ee3b389-716f-4ffe-b51d-f2ba836753a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

